### PR TITLE
Add buildLatestSpec function

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 node_modules
 .nyc_output
+*.swp
+*/**/*.swp

--- a/index.js
+++ b/index.js
@@ -72,6 +72,13 @@ class RegistryResolver {
     return pkgReg.extractDependenciesFromManifest({ manifest })
   }
 
+  buildLatestSpec (pkgName, { language, registry }) {
+    const pkgReg = this.getSupportedRegistry({ language, registry })
+    if (!pkgReg) throw new Error(`unsupported language/registry ${language} / ${registry}`)
+
+    return pkgReg.buildLatestSpec(pkgName)
+  }
+
   getSupportedRegistry ({ language, registry }) {
     if (!registry || !language) return false
     if (!this.registries[language]) return false

--- a/npm/index.js
+++ b/npm/index.js
@@ -16,6 +16,13 @@ class NpmDependencyResolver {
     return ['package.json']
   }
 
+  // returns a string in the form of a top level dependency that specifies
+  // the latest version of this package on the registry; for NPM, that's done
+  // by specifiying @latest instead of a version number
+  buildLatestSpec (pkgName) {
+    return `${pkgName}@latest`
+  }
+
   extractDependenciesFromManifest({ manifest }) {
     const parsedManifest = this.parseManifest({ manifest })
     const deps = parsedManifest.dependencies || {}

--- a/npm/test/index.test.js
+++ b/npm/test/index.test.js
@@ -139,3 +139,7 @@ test('resolve | pacote dies', async (t) => {
   t.context.npm.getManifest.rejects()
   t.deepEqual(await t.context.npm.resolve('js-deep-equals'), {})
 })
+
+test('buildLatestSpec', (t) => {
+  t.is(t.context.npm.buildLatestSpec('sodium'), 'sodium@latest')
+})

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@flossbank/registry-resolver",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@flossbank/registry-resolver",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "Resolve list of packages into weighted map of dependencies",
   "main": "index.js",
   "scripts": {

--- a/rubygems/index.js
+++ b/rubygems/index.js
@@ -21,6 +21,13 @@ class RubyGemsDependencyResolver {
     return ['Gemfile']
   }
 
+  // returns a string in the form of a top level dependency that specifies
+  // the latest version of this package on the registry; for Ruby, not specifying
+  // a version means you want the latest
+  buildLatestSpec (pkgName) {
+    return pkgName
+  }
+
   // Def: given a raw file (i.e. the bytes of Gemfile), return a list ([]) of
   //  dependencies that are listed in the manifest file. The format of each entry in the list
   //  should be consumable (one at a time) by getSpec.

--- a/rubygems/test/index.test.js
+++ b/rubygems/test/index.test.js
@@ -404,3 +404,7 @@ test('resolveToSpec | throws', async (t) => {
   const spec = await t.context.rubygems.resolveToSpec("gem 'rubocop', '>= 4.0.0'")
   t.deepEqual(spec, "gem 'rubocop', '>= 4.0.0'")
 })
+
+test('buildLatestSpec', (t) => {
+  t.is(t.context.rubygems.buildLatestSpec('sodium'), 'sodium')
+})

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -191,6 +191,21 @@ test('resolveToSpec | success', async (t) => {
   t.deepEqual(res, ['a@1.0.0'])
 })
 
+test('buildLatestSpec', (t) => {
+  const { resolver } = t.context
+  resolver.registries.javascript.npm.buildLatestSpec = () => 'validspec'
+
+  const spec = resolver.buildLatestSpec('asdf', { language: 'javascript', registry: 'npm' })
+  t.is(spec, 'validspec')
+})
+
+test('buildLatestSpec | invalid lang reg combo', (t) => {
+  const { resolver } = t.context
+  resolver.registries.javascript.npm.buildLatestSpec = () => 'validspec'
+
+  t.throws(() => resolver.buildLatestSpec('asdf', { language: 'papascript', registry: 'npm' }))
+})
+
 test('getSupportedManifestPatterns', (t) => {
   const { resolver } = t.context
   resolver.registries.javascript.npm.getManifestPatterns = () => ['package.json']


### PR DESCRIPTION
So that, given a package from our own DB, we can turn it into a "top level dep" and then fetch its deps.